### PR TITLE
feat(datastore): fix member visibility and remove inappropriate override

### DIFF
--- a/common/datastore/CDataStore.cpp
+++ b/common/datastore/CDataStore.cpp
@@ -188,6 +188,12 @@ CDataStore& CDataStore::GetString(char* val, uint32_t maxChars) {
     return *this;
 }
 
+void CDataStore::Initialize() {
+    if (this->m_alloc != -1) {
+        this->InternalInitialize(this->m_data, this->m_base, this->m_alloc);
+    }
+}
+
 void CDataStore::InternalDestroy(uint8_t*& data, uint32_t& base, uint32_t& alloc) {
     if (alloc && data) {
         SMemFree(data, __FILE__, __LINE__, 0);

--- a/common/datastore/CDataStore.hpp
+++ b/common/datastore/CDataStore.hpp
@@ -5,13 +5,6 @@
 
 class CDataStore {
     public:
-    // Member variables
-    uint8_t* m_data = nullptr;
-    uint32_t m_base = 0;
-    uint32_t m_alloc = 0;
-    uint32_t m_size = 0;
-    uint32_t m_read = -1;
-
     // Virtual member functions
     virtual void InternalInitialize(uint8_t*& data, uint32_t& base, uint32_t& alloc) {};
     virtual void InternalDestroy(uint8_t*& data, uint32_t& base, uint32_t& alloc);
@@ -36,6 +29,7 @@ class CDataStore {
     CDataStore& Get(float& val);
     CDataStore& GetDataInSitu(void*& val, uint32_t bytes);
     CDataStore& GetString(char* val, uint32_t maxChars);
+    void Initialize();
     int32_t IsFinal();
     int32_t IsValid();
     CDataStore& Put(uint8_t val);
@@ -51,6 +45,14 @@ class CDataStore {
     uint32_t Size();
     uint32_t Tell();
     bool Sub8CBBF0(uint32_t a2);
+
+    private:
+    // Member variables
+    uint8_t* m_data = nullptr;
+    uint32_t m_base = 0;
+    uint32_t m_alloc = 0;
+    uint32_t m_size = 0;
+    uint32_t m_read = -1;
 };
 
 #endif

--- a/common/datastore/CDataStoreCache.hpp
+++ b/common/datastore/CDataStoreCache.hpp
@@ -18,21 +18,13 @@ class CDataStoreCache : public CDataStore {
 
     // Member functions
     CDataStoreCache() {
-        this->InternalInitialize(this->m_data, this->m_base, this->m_alloc);
+        this->Initialize();
     }
-    void Destroy();
 };
 
 template <size_t size>
 CDataStoreCache<size>::~CDataStoreCache() {
     this->Destroy();
-}
-
-template <size_t size>
-void CDataStoreCache<size>::Destroy() {
-    if (this->m_alloc != -1) {
-        this->InternalDestroy(this->m_data, this->m_base, this->m_alloc);
-    }
 }
 
 template <size_t size>

--- a/test/DataStore.cpp
+++ b/test/DataStore.cpp
@@ -93,7 +93,7 @@ TEST_CASE("CDataStore::Get", "[datastore]") {
         msg.GetString(readVal, 3);
 
         REQUIRE(SStrCmp(readVal, "foo", STORM_MAX_STR) == 0);
-        REQUIRE(msg.m_read == 3);
+        REQUIRE(msg.Tell() == 3);
     }
 
     SECTION("gets string honoring maxchars of 0") {
@@ -105,7 +105,7 @@ TEST_CASE("CDataStore::Get", "[datastore]") {
         msg.Finalize();
         msg.GetString(readVal, 0);
 
-        REQUIRE(msg.m_read == 0);
+        REQUIRE(msg.Tell() == 0);
     }
 }
 


### PR DESCRIPTION
This PR makes all member fields in `CDataStore` private (as they are in the client). To facilitate making the member fields private, this PR also addresses two other issues with:
- Remove `CDataStoreCache::Destroy` (which doesn't exist)
- Add `CDataStore::Initialize` (which does exist and is used by the `CDataStoreCache` constructor)